### PR TITLE
SPT-473: Update CODEOWNERS for new org

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @alphagov/digital-identity-support
+* @govuk-one-login/govuk-one-login-all


### PR DESCRIPTION
## What?

- Update `CODEOWNERS` with `@govuk-one-login/govuk-one-login-all` as the sole entry.

## Why?

In preparation for transition to new org.
